### PR TITLE
Save before deploy

### DIFF
--- a/addons/rivet/devtools/dock/deploy_tab.gd
+++ b/addons/rivet/devtools/dock/deploy_tab.gd
@@ -5,29 +5,48 @@
 @onready var build_deploy_button: Button = %BuildDeployButton
 
 func _ready() -> void:
-    manage_versions_button.pressed.connect(_on_manage_versions_button_pressed)
-    build_deploy_button.pressed.connect(_on_build_deploy_button_pressed)
+	manage_versions_button.pressed.connect(_on_manage_versions_button_pressed)
+	build_deploy_button.pressed.connect(_on_build_deploy_button_pressed)
 
 func _on_manage_versions_button_pressed() -> void:
-    _all_actions_set_disabled(true)
-    
-    var result = await RivetPluginBridge.get_plugin().cli.run_command(["sidekick", "get-version", "--namespace", namespace_selector.current_value.namespace_id])
-    if result.exit_code != 0 or !("Ok" in result.output):
-        RivetPluginBridge.display_cli_error(self, result)
+	_all_actions_set_disabled(true)
+	
+	var result = await RivetPluginBridge.get_plugin().cli.run_command(["sidekick", "get-version", "--namespace", namespace_selector.current_value.namespace_id])
+	if result.exit_code != 0 or !("Ok" in result.output):
+		RivetPluginBridge.display_cli_error(self, result)
 
-    OS.shell_open(result.output["Ok"]["output"])
-    _all_actions_set_disabled(false)
+	OS.shell_open(result.output["Ok"]["output"])
+	_all_actions_set_disabled(false)
 
 func _on_build_deploy_button_pressed() -> void:
-    _all_actions_set_disabled(true)
+	# First, ask the user if they want to save their scenes
+	var dialog = ConfirmationDialog.new()
+	dialog.dialog_text = "Would you like to save your scenes before building and deploying?"
+	dialog.connect("confirmed", save_before_build_and_deploy)
+	dialog.get_cancel_button().pressed.connect(build_and_deploy)
+	dialog.cancel_button_text = "No, just build and deploy"
+	self.add_child(dialog)
+	dialog.popup_centered()
 
-    var result = await RivetPluginBridge.get_plugin().cli.run_command(["sidekick", "--show-terminal", "deploy", "--namespace", namespace_selector.current_value.name_id])
-    if result.exit_code != 0:
-        RivetPluginBridge.display_cli_error(self, result)
 
-    _all_actions_set_disabled(false)
-    
+func save_before_build_and_deploy() -> void:
+	# Save all scenes
+	EditorInterface.save_all_scenes()
+
+	# Now, build and deploy
+	build_and_deploy()
+
+
+func build_and_deploy() -> void:
+	_all_actions_set_disabled(true)
+
+	var result = await RivetPluginBridge.get_plugin().cli.run_command(["sidekick", "--show-terminal", "deploy", "--namespace", namespace_selector.current_value.name_id])
+	if result.exit_code != 0:
+		RivetPluginBridge.display_cli_error(self, result)
+
+	_all_actions_set_disabled(false)
+	
 func _all_actions_set_disabled(disabled: bool) -> void:
-    namespace_selector.disabled = disabled
-    manage_versions_button.disabled = disabled
-    build_deploy_button.disabled = disabled
+	namespace_selector.disabled = disabled
+	manage_versions_button.disabled = disabled
+	build_deploy_button.disabled = disabled


### PR DESCRIPTION
This will close GDT-92 and GDT-76.

---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request includes changes to the `deploy_tab.gd` file in the Rivet DevTools. The changes primarily involve reformatting and adding a line to ensure all scenes are saved before deployment.
> 
> ## What changed
> The changes in this pull request are mainly about reformatting the code to improve readability. The indentation has been changed from spaces to tabs. 
> 
> Additionally, a line of code has been added to ensure that all scenes are saved before the build and deploy button is pressed. This is to prevent any unsaved changes from being lost during the deployment process.
> 
> ## How to test
> To test these changes, follow these steps:
> 
> 1. Open the Rivet DevTools in Godot.
> 2. Navigate to the Deploy tab.
> 3. Make some changes in your scenes but do not save them.
> 4. Press the Build and Deploy button.
> 5. Check if the changes you made are included in the deployed version.
> 
> ## Why make this change
> This change is necessary to prevent loss of unsaved changes during the deployment process. By ensuring that all scenes are saved before deployment, we can avoid potential issues and confusion for the users. The reformatting of the code also improves readability, making it easier for other developers to understand and maintain the code.
</details>