### PR TITLE
Remove cli path setting hint

### DIFF
--- a/addons/rivet/devtools/rivet_editor_settings.gd
+++ b/addons/rivet/devtools/rivet_editor_settings.gd
@@ -1,7 +1,6 @@
 const RIVET_CLI_PATH_SETTING = {
     "name": "rivet/cli_executable_path",
     "type": TYPE_STRING,
-    "hint": PROPERTY_HINT_TYPE_STRING,
 }
 const RIVET_DEBUG_SETTING ={
     "name": "rivet/debug",


### PR DESCRIPTION
Since Godot crashes when hint/hint string aren't set up properly (https://github.com/godotengine/godot/issues/85235), it would be best to remove the hint for now.

I tried adding `type_hint`, but I couldn't get it to work right away. Probably worth looking into later.