### PR TITLE
feat: logs and lobbies link buttons

### DIFF
--- a/addons/rivet/devtools/dock/deploy_tab.gd
+++ b/addons/rivet/devtools/dock/deploy_tab.gd
@@ -1,17 +1,41 @@
 @tool extends MarginContainer
 
 @onready var namespace_selector: OptionButton = %DeployNamespaceSelector
-@onready var manage_versions_button: Button = %ManageVersionButton
 @onready var build_deploy_button: Button = %BuildDeployButton
+@onready var manage_versions_button: Button = %ManageVersionButton
+@onready var logs_button: Button = %LogsButton
+@onready var lobbies_button: Button = %LobbiesButton
 
 func _ready() -> void:
-	manage_versions_button.pressed.connect(_on_manage_versions_button_pressed)
 	build_deploy_button.pressed.connect(_on_build_deploy_button_pressed)
+	manage_versions_button.pressed.connect(_on_manage_versions_button_pressed)
+	logs_button.pressed.connect(_on_logs_button_pressed)
+	lobbies_button.pressed.connect(_on_lobbies_button_pressed)
 
 func _on_manage_versions_button_pressed() -> void:
 	_all_actions_set_disabled(true)
 
 	var result = await RivetPluginBridge.get_plugin().cli.run_and_wait(["sidekick", "get-version", "--namespace", namespace_selector.current_value.namespace_id])
+	if result.exit_code != 0 or !("Ok" in result.output):
+		RivetPluginBridge.display_cli_error(self, result)
+
+	OS.shell_open(result.output["Ok"]["output"])
+	_all_actions_set_disabled(false)
+
+func _on_logs_button_pressed() -> void:
+	_all_actions_set_disabled(true)
+
+	var result = await RivetPluginBridge.get_plugin().cli.run_and_wait(["sidekick", "get-logs", "--namespace", namespace_selector.current_value.namespace_id])
+	if result.exit_code != 0 or !("Ok" in result.output):
+		RivetPluginBridge.display_cli_error(self, result)
+
+	OS.shell_open(result.output["Ok"]["output"])
+	_all_actions_set_disabled(false)
+
+func _on_lobbies_button_pressed() -> void:
+	_all_actions_set_disabled(true)
+
+	var result = await RivetPluginBridge.get_plugin().cli.run_and_wait(["sidekick", "get-lobbies", "--namespace", namespace_selector.current_value.namespace_id])
 	if result.exit_code != 0 or !("Ok" in result.output):
 		RivetPluginBridge.display_cli_error(self, result)
 
@@ -51,3 +75,5 @@ func _all_actions_set_disabled(disabled: bool) -> void:
 	namespace_selector.disabled = disabled
 	manage_versions_button.disabled = disabled
 	build_deploy_button.disabled = disabled
+	logs_button.disabled = disabled
+	lobbies_button.disabled = disabled

--- a/addons/rivet/devtools/dock/deploy_tab.tscn
+++ b/addons/rivet/devtools/dock/deploy_tab.tscn
@@ -53,3 +53,20 @@ layout_mode = 2
 size_flags_horizontal = 3
 mouse_default_cursor_shape = 2
 text = "Manage Versions"
+
+[node name="Links" type="HBoxContainer" parent="Deployment Fields"]
+layout_mode = 2
+
+[node name="LogsButton" type="Button" parent="Deployment Fields/Links"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+mouse_default_cursor_shape = 2
+text = "Logs"
+
+[node name="LobbiesButton" type="Button" parent="Deployment Fields/Links"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+mouse_default_cursor_shape = 2
+text = "Lobbies"


### PR DESCRIPTION
This will close GDT-126

This is blocked by https://github.com/rivet-gg/cli/pull/235 and a new version of the CLI being released.